### PR TITLE
Artdir subdirectories not installing correctly

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1,6 +1,8 @@
 SUBDIRS = src
 lcsdir = $(datadir)/lcs
 artdir = $(lcsdir)/art
+mididir = $(artdir)/midi
+oggdir = $(artdir)/ogg
 appdir = $(datadir)/applications
 
 dist_art_DATA = art/abort.cmv art/anchor.cmv art/glamshow.cmv art/lacops.cmv\
@@ -22,8 +24,9 @@ dist_art_DATA = art/abort.cmv art/anchor.cmv art/glamshow.cmv art/lacops.cmv\
  art/mapCSV_NuclearPlant_Specials.csv art/mapCSV_NuclearPlant_Tiles.csv\
  art/mapCSV_WhiteHouse_Specials.csv art/mapCSV_WhiteHouse_Tiles.csv\
  art/mapCSV_WhiteHouse2_Specials.csv art/mapCSV_WhiteHouse2_Tiles.csv\
- art/mapCSV_WhiteHouse3_Specials.csv art/mapCSV_WhiteHouse3_Tiles.csv\
- \
+ art/mapCSV_WhiteHouse3_Specials.csv art/mapCSV_WhiteHouse3_Tiles.csv
+
+dist_midi_DATA = \
  art/midi/abort.mid art/midi/activate.mid art/midi/alarmed.mid art/midi/anchor.mid\
  art/midi/basemode.mid art/midi/carchase.mid art/midi/cartheft.mid art/midi/dating.mid\
  art/midi/defeat.mid art/midi/disbanded.mid art/midi/elections.mid art/midi/finances.mid\
@@ -32,8 +35,9 @@ dist_art_DATA = art/abort.cmv art/anchor.cmv art/glamshow.cmv art/lacops.cmv\
  art/midi/newspaper.mid art/midi/reaganified.mid art/midi/recruiting.mid art/midi/reviewmode.mid\
  art/midi/shopping.mid art/midi/siege.mid art/midi/sitemode.mid art/midi/sleepers.mid\
  art/midi/stalinized.mid art/midi/stopevil.mid art/midi/suspicious.mid art/midi/titlemode.mid\
- art/midi/trial.mid art/midi/victory.mid\
- \
+ art/midi/trial.mid art/midi/victory.mid
+
+dist_ogg_DATA = \
  art/ogg/abort.ogg art/ogg/activate.ogg art/ogg/alarmed.ogg art/ogg/anchor.ogg\
  art/ogg/basemode.ogg art/ogg/carchase.ogg art/ogg/cartheft.ogg art/ogg/dating.ogg\
  art/ogg/defeat.ogg art/ogg/disbanded.ogg art/ogg/elections.ogg art/ogg/finances.ogg\


### PR DESCRIPTION
I packaged lcs for nixpkgs, but I ran into a issue that the sound doesn't play, and I think the problem is with lcs' build. Looking at the ENOENTs from strace, it seems the game is looking for sounds in /foo/lcs/art/midi/filename.midi, but the file is actually on /foo/lcs/art/filename.midi. 

https://github.com/Kamal-Sadek/Liberal-Crime-Squad/blob/master/src/common/misc.cpp#L431 tries to load from $artdir/midi/filename. 

Running make install-dist_artDATA DESTDIR=/tmp/test, I get this:

```
 /nix/store/1fy1p7366rr924m7k5yidhlk5sv9r6vw-coreutils-8.25/bin/mkdir -p '/tmp/test/nix/store/2fapplh19ll8070b368vnikvqmlzgvvg-liberal-crime-squad-2016-05-08/share/lcs/art'
 /nix/store/1fy1p7366rr924m7k5yidhlk5sv9r6vw-coreutils-8.25/bin/install -c -m 644 art/abort.cmv art/anchor.cmv art/glamshow.cmv art/lacops.cmv art/newscast.cmv art/largecap.cpc art/newspic.cpc art/newstops.cpc art/armors.xml art/augmentations.xml art/armsdealer.xml art/clips.xml art/creatures.xml art/deptstore.xml art/loot.xml art/masks.xml art/oubliette.xml art/pawnshop.xml art/vehicles.xml art/weapons.xml art/licenses.txt art/sitemaps.txt art/mapCSV_Bank_Specials.csv art/mapCSV_Bank_Tiles.csv art/mapCSV_BarAndGrill_Specials.csv art/mapCSV_BarAndGrill_Tiles.csv art/mapCSV_BombShelter_Specials.csv art/mapCSV_BombShelter_Tiles.csv art/mapCSV_Bunker_Specials.csv art/mapCSV_Bunker_Tiles.csv art/mapCSV_Courthouse_Specials.csv art/mapCSV_Courthouse_Tiles.csv art/mapCSV_NuclearPlant_Specials.csv art/mapCSV_NuclearPlant_Tiles.csv art/mapCSV_WhiteHouse_Specials.csv art/mapCSV_WhiteHouse_Tiles.csv art/mapCSV_WhiteHouse2_Specials.csv art/mapCSV_WhiteHouse2_Tiles.csv art/mapCSV_WhiteHouse3_Specials.csv art/mapCSV_WhiteHouse3_Tiles.csv '/tmp/test/nix/store/2fapplh19ll8070b368vnikvqmlzgvvg-liberal-crime-squad-2016-05-08/share/lcs/art'
 /nix/store/1fy1p7366rr924m7k5yidhlk5sv9r6vw-coreutils-8.25/bin/install -c -m 644 art/midi/abort.mid art/midi/activate.mid art/midi/alarmed.mid art/midi/anchor.mid art/midi/basemode.mid art/midi/carchase.mid art/midi/cartheft.mid art/midi/dating.mid art/midi/defeat.mid art/midi/disbanded.mid art/midi/elections.mid art/midi/finances.mid art/midi/footchase.mid art/midi/glamshow.mid art/midi/heavycombat.mid art/midi/interrogation.mid art/midi/lacops.mid art/midi/liberalagenda.mid art/midi/newgame.mid art/midi/newscast.mid art/midi/newspaper.mid art/midi/reaganified.mid art/midi/recruiting.mid art/midi/reviewmode.mid art/midi/shopping.mid art/midi/siege.mid art/midi/sitemode.mid art/midi/sleepers.mid art/midi/stalinized.mid art/midi/stopevil.mid art/midi/suspicious.mid art/midi/titlemode.mid art/midi/trial.mid art/midi/victory.mid art/ogg/abort.ogg art/ogg/activate.ogg art/ogg/alarmed.ogg art/ogg/anchor.ogg art/ogg/basemode.ogg art/ogg/carchase.ogg '/tmp/test/nix/store/2fapplh19ll8070b368vnikvqmlzgvvg-liberal-crime-squad-2016-05-08/share/lcs/art'
 /nix/store/1fy1p7366rr924m7k5yidhlk5sv9r6vw-coreutils-8.25/bin/install -c -m 644 art/ogg/cartheft.ogg art/ogg/dating.ogg art/ogg/defeat.ogg art/ogg/disbanded.ogg art/ogg/elections.ogg art/ogg/finances.ogg art/ogg/footchase.ogg art/ogg/glamshow.ogg art/ogg/heavycombat.ogg art/ogg/interrogation.ogg art/ogg/lacops.ogg art/ogg/liberalagenda.ogg art/ogg/newgame.ogg art/ogg/newscast.ogg art/ogg/newspaper.ogg art/ogg/reaganified.ogg art/ogg/recruiting.ogg art/ogg/reviewmode.ogg art/ogg/shopping.ogg art/ogg/siege.ogg art/ogg/sitemode.ogg art/ogg/sleepers.ogg art/ogg/stalinized.ogg art/ogg/stopevil.ogg art/ogg/suspicious.ogg art/ogg/titlemode.ogg art/ogg/trial.ogg art/ogg/victory.ogg '/tmp/test/nix/store/2fapplh19ll8070b368vnikvqmlzgvvg-liberal-crime-squad-2016-05-08/share/lcs/art'

```

I think the target should be .../lcs/art/midi/ for things that should go in midi, not just /lcs/art. 

Maybe dist_art_DATA from https://github.com/Kamal-Sadek/Liberal-Crime-Squad/blob/master/Makefile.am needs to be split depending on which folder it should end up? I'm not really familiar with autotools, sorry.

Problem also applies to ogg files.